### PR TITLE
Add approving tips for admins

### DIFF
--- a/app/controllers/__init__.py
+++ b/app/controllers/__init__.py
@@ -15,6 +15,7 @@ from .fast_add_ingredients import FastAddIngredientsView
 from .ingredient_categories import IngredientCategoriesView
 from .recipe_categories import RecipeCategoriesView
 from .measurements import MeasurementsView
+from .tips import TipsView
 
 from .recipes import RecipesView
 from .edit_recipes import EditRecipeView
@@ -38,8 +39,9 @@ __all__ = [
     "IngredientsView",
     "FastAddIngredientsView",
     "IngredientCategoriesView",
-    "MeasurementsView",
     "RecipeCategoriesView",
+    "MeasurementsView",
+    "TipsView",
     "RecipesView",
     "EditRecipeView",
     "PublicRecipesView",
@@ -71,6 +73,7 @@ def register_all_controllers(application):
     IngredientCategoriesView.register(application, base_class=HelperFlaskView)
 
     MeasurementsView.register(application, base_class=HelperFlaskView)
+    TipsView.register(application, base_class=HelperFlaskView)
 
     RecipeCategoriesView.register(application, base_class=HelperFlaskView)
 

--- a/app/controllers/tips.py
+++ b/app/controllers/tips.py
@@ -1,0 +1,63 @@
+from flask import redirect, url_for
+from flask_security import login_required, roles_accepted
+
+from app import turbo
+
+from flask_classful import route
+
+from app.models.tips import Tip
+
+from app.helpers.helper_flask_view import HelperFlaskView
+
+
+class TipsView(HelperFlaskView):
+    decorators = [login_required, roles_accepted("admin", "application_manager")]
+
+    @login_required
+    def before_request(self, name, id=None, *args, **kwargs):
+        self.tip = Tip.load(id)
+        self.validate_operation(id, self.tip)
+
+    def before_index(self):
+        self.tips = Tip.load_all()
+        self.unapproved_tips = Tip.unapproved_tips()
+        self.unapproved_tips.sort(key=lambda x: x.created_at, reverse=True)
+        self.approved_tips = Tip.approved_tips()
+        self.approved_tips.sort(key=lambda x: x.created_at, reverse=True)
+        self.disapproved_tips = Tip.disapproved_tips()
+        self.disapproved_tips.sort(key=lambda x: x.created_at, reverse=True)
+
+    def index(self):
+        return self.template()
+
+    @route("/approve/<id>", methods=["POST"])
+    def approve(self, id):
+        self.tip.approve()
+
+        if turbo.can_stream():
+            return turbo.stream(
+                [
+                    turbo.remove(target=f"tip-{id}"),
+                    turbo.prepend(
+                        self.template(template_name="_tip"), target="approved-tips"
+                    ),
+                ]
+            )
+        else:
+            return redirect(url_for("TipsView:index"))
+
+    @route("/disapprove/<id>", methods=["POST"])
+    def disapprove(self, id):
+        self.tip.disapprove()
+
+        if turbo.can_stream():
+            return turbo.stream(
+                [
+                    turbo.remove(target=f"tip-{id}"),
+                    turbo.prepend(
+                        self.template(template_name="_tip"), target="disapproved-tips"
+                    ),
+                ]
+            )
+        else:
+            return redirect(url_for("TipsView:index"))

--- a/app/helpers/base_mixin.py
+++ b/app/helpers/base_mixin.py
@@ -26,7 +26,7 @@ class BaseMixin(object):
 
     @classmethod
     def load_all(cls):
-        return cls.query.filter_by(is_visible=True).all()
+        return cls.query.all()
 
     @classmethod
     def load_last(cls):
@@ -153,13 +153,6 @@ class BaseMixin(object):
             return self.is_shared
         else:
             return False
-
-    @hybrid_property
-    def is_visible(self) -> bool:
-        if hasattr(self, "is_visible"):
-            return self.is_visible
-        else:
-            return True
 
     # PERMISSIONS
     def can_view(self, user) -> bool:

--- a/app/models/tips.py
+++ b/app/models/tips.py
@@ -12,6 +12,7 @@ class Tip(db.Model, BaseMixin):
     description = db.Column(db.Text, nullable=False)
 
     is_approved = db.Column(db.Boolean(), default=False, nullable=False)
+    is_hidden = db.Column(db.Boolean(), default=False, nullable=False)
 
     author = db.relationship("User", uselist=False, backref="tips")
 
@@ -23,3 +24,23 @@ class Tip(db.Model, BaseMixin):
     def approved_tips():
         tips = Tip.query.filter(Tip.is_approved).all()
         return tips
+
+    @staticmethod
+    def disapproved_tips():
+        tips = Tip.query.filter(Tip.is_hidden).all()
+        return tips
+
+    @staticmethod
+    def unapproved_tips():
+        tips = Tip.query.filter_by(is_approved=False, is_hidden=False).all()
+        return tips
+
+    def approve(self):
+        self.is_approved = True
+        self.is_hidden = False
+        self.save()
+
+    def disapprove(self):
+        self.is_approved = False
+        self.is_hidden = True
+        self.save()

--- a/app/static/css/lists.css
+++ b/app/static/css/lists.css
@@ -128,3 +128,25 @@ ul.list {
 }
 
 
+.list li .approve {
+	/*display: none;*/
+	position: absolute;
+	border: 0px;
+	top: 10px;
+	right: 50px;
+	bottom: 1px;
+	width: 40px;
+	height: 40px;
+	margin: auto 0;
+	font-size: 30px;
+	/*margin-bottom: 11px;*/
+	transition: color 0.2s ease-out;
+}
+
+.list li button.approve  {
+	font-size: 1rem;
+}
+
+.list li .approve:after {
+	content: '✔️';
+} .

--- a/app/templates/navbars/_navbar_admin.html.j2
+++ b/app/templates/navbars/_navbar_admin.html.j2
@@ -9,6 +9,7 @@
         <a class="dropdown-item" href="{{ url_for('MeasurementsView:index') }}"> 			Míry 				</a>
 		<a class="dropdown-item" href="{{ url_for('IngredientCategoriesView:index') }}">	Kategorie surovin	</a>
 		<a class="dropdown-item" href="{{ url_for('RecipeCategoriesView:index') }}"> 		Kategorie receptů	</a>
+		<a class="dropdown-item" href="{{ url_for('TipsView:index') }}">			 		Tipy				</a>
 	</div>
 </li>
 

--- a/app/templates/tips/_tip.html.j2
+++ b/app/templates/tips/_tip.html.j2
@@ -1,0 +1,13 @@
+{% from "macros/turbo.html.j2" import button_to %}
+
+<turbo-frame id="tip-{{ tip.id }}">
+  <li class="row">
+      <div> {{ tip.description }} (přidal*a {{ tip.author.full_name }} v {{ human_format_date(tip.created_at, with_weekday=False) }}) </div>
+    {% if not edit_id %}
+      {% if not tip.is_approved %}
+        {{ button_to(action=url_for('TipsView:approve', id=tip.id), class="approve", data="all") }}
+      {% endif %}
+      {{ button_to(action=url_for('TipsView:disapprove', id=tip.id), class="destroy") }}
+    {% endif %}
+  </li>
+</turbo-frame>

--- a/app/templates/tips/index.html.j2
+++ b/app/templates/tips/index.html.j2
@@ -1,0 +1,58 @@
+{% extends "base/base.html.j2" %}
+{% block title %} Tipy - admin {% endblock %}
+
+{% block links %}
+    {{ super() }}
+    {{ turbo() }}
+{% endblock %}
+
+{% block content %}
+
+<div class="text-center">
+  <h1 class="text-uppercase font-comfortaa">Tipy - ke schválení</h1>
+
+    <ul class="list">
+      <turbo-frame id="unapproved-tips">
+        {% for tip in unapproved_tips %}
+            {% include 'tips/_tip.html.j2' %}
+        {% endfor %}
+      </turbo-stream>
+    </ul>
+
+  <div class="mt-5">
+  <details>
+    <summary>
+      Schválené tipy
+    </summary>
+
+    <ul class="list">
+      <turbo-frame id="approved-tips">
+        {% for tip in approved_tips %}
+            {% include 'tips/_tip.html.j2' %}
+        {% endfor %}
+      </turbo-stream>
+    </ul> 
+  </details>
+  </div>
+
+  <div class="mt-5">
+  <details>
+    <summary>
+      Zamítnuté tipy
+    </summary>
+
+    <ul class="list">
+      <turbo-frame id="disapproved-tips">
+        {% for tip in disapproved_tips %}
+            {% include 'tips/_tip.html.j2' %}
+        {% endfor %}
+      </turbo-stream>
+    </ul> 
+  </details>
+  </div>
+
+
+</div>
+
+{% endblock %}
+

--- a/migrations/versions/21_07_12_hidden_tips.py
+++ b/migrations/versions/21_07_12_hidden_tips.py
@@ -1,0 +1,24 @@
+"""Add hidden to tips
+
+Revision ID: 1dd7f127a503
+Revises: 5c6b8f2d4bd8
+Create Date: 2021-07-12 18:30:44.279901
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "1dd7f127a503"
+down_revision = "5c6b8f2d4bd8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("tips", sa.Column("is_hidden", sa.Boolean(), nullable=False))
+
+
+def downgrade():
+    op.drop_column("tips", "is_hidden")


### PR DESCRIPTION
Umožňuje adminům/application managerům schvalovat / skrývat tipy, které přidávají uživatelé.

Měl by na to navazovat další rozvoj adminu - admin dashboard, kde je vidět, že jsou nějaké neschválené (případně nějaký notification dot). 


Closes #25 