### PR TITLE
Group ingredients in shopping exports by category

### DIFF
--- a/app/controllers/event_exporter.py
+++ b/app/controllers/event_exporter.py
@@ -66,6 +66,9 @@ class EventExporterView(HelperFlaskView):
         self.lasting_ingredients_shopping = Shopping()
         self.lasting_ingredients_shopping.shopping_list = self.lasting_ingredients
         self.lasting_ingredients_shopping.daily_recipes = self.event.daily_recipes
+        self.lasting_ingredients_shopping.grouped_shopping_list = (
+            self._grouped_ingredients(self.lasting_ingredients)
+        )
 
         # a pak pro každý mezinákupový období
         self.shoppings = []
@@ -87,6 +90,7 @@ class EventExporterView(HelperFlaskView):
             self._sort_ingredients(shopping_list)
 
             shopping.shopping_list = shopping_list
+            shopping.grouped_shopping_list = self._grouped_ingredients(shopping_list)
             self.shoppings.append(shopping)
 
     def _sort_ingredients(self, list_of_ingredients):
@@ -96,6 +100,17 @@ class EventExporterView(HelperFlaskView):
                 unidecode(x.name.lower()),
             )
         )
+
+    def _grouped_ingredients(self, list_of_ingredients):
+        grouped_ingredients = {}
+        unused_ingredient_categories = [i.category_name for i in list_of_ingredients]
+        for c in unused_ingredient_categories:
+            grouped_ingredients[c] = []
+
+        for i in list_of_ingredients:
+            grouped_ingredients[i.category_name].append(i)
+
+        return grouped_ingredients
 
     def _get_amounts_for_shopping(self, shopping=None):
         used_recipes = [r.recipe for r in shopping.daily_recipes]

--- a/app/models/ingredients.py
+++ b/app/models/ingredients.py
@@ -144,6 +144,10 @@ class Ingredient(db.Model, ItemMixin):
             self.measurement
         ]
 
+    @property
+    def category_name(self):
+        return getattr(self.category, "name", "---")
+
     # @property
     # def is_in_thousands(self):
     #     return self.measurement.thousand_fold and self.amount % 1000 != self.amount
@@ -182,6 +186,10 @@ class IngredientCopy:
             recipe_id=recipe.id, ingredient_id=self.id
         ).first()
         return rhi.amount
+
+    @property
+    def category_name(self):
+        return getattr(self.category, "name", "---")
 
     # CONTEXT PROCESSOR UTILITIES
     @property

--- a/app/templates/event_exporter/_ingredient_list.html.j2
+++ b/app/templates/event_exporter/_ingredient_list.html.j2
@@ -1,36 +1,40 @@
 <ul>
-    {% for ingredient in ingredients %}
-    	<li>
-    		<details>
-    			<summary class="row">
-        			<span class="col font-weight-bold">
-                        {{ link_or_name(ingredient) }}
-                    </span>
-                        {% if ingredient.measurement.thousand_fold and ingredient.amount % 1000 != ingredient.amount %}
-                            <span class="col font-weight-bold"> {{ formatted_amount(ingredient.amount/1000) }} </span>
-                            <span class="col font-weight-bold"> {{ ingredient.measurement.thousand_fold }} </span>
-                        {% else %}
-                            <span class="col font-weight-bold"> {{ formatted_amount(ingredient.amount) }} </span>
-                            <span class="col font-weight-bold"> {{ ingredient.measurement.name }} </span>
-                        {% endif %}
-    			</summary>
+    {% for group, ingredients in groups.items() %}
+        <hr>
+        <h6> {{ group }} </h6>
+        {% for ingredient in ingredients %}
+        	<li>
+        		<details>
+        			<summary class="row">
+            			<span class="col font-weight-bold">
+                            {{ link_or_name(ingredient) }}
+                        </span>
+                            {% if ingredient.measurement.thousand_fold and ingredient.amount % 1000 != ingredient.amount %}
+                                <span class="col font-weight-bold"> {{ formatted_amount(ingredient.amount/1000) }} </span>
+                                <span class="col font-weight-bold"> {{ ingredient.measurement.thousand_fold }} </span>
+                            {% else %}
+                                <span class="col font-weight-bold"> {{ formatted_amount(ingredient.amount) }} </span>
+                                <span class="col font-weight-bold"> {{ ingredient.measurement.name }} </span>
+                            {% endif %}
+        			</summary>
 
-		    	{% for recipe in ingredient.event_recipes %}
-                    {% set amount = amounts[ingredient.id]["recipes"][recipe.id]["amount"] %}
-                    {% set occurences = amounts[ingredient.id]["recipes"][recipe.id]["occurences"] %}
+    		    	{% for recipe in ingredient.event_recipes %}
+                        {% set amount = amounts[ingredient.id]["recipes"][recipe.id]["amount"] %}
+                        {% set occurences = amounts[ingredient.id]["recipes"][recipe.id]["occurences"] %}
 
-                    <li class="row"> 
-                        <span class="col"> {{ link_or_name(recipe) }} {% if occurences > 1 %}({{ occurences }}x){% endif %} </span>
-                        {% if ingredient.measurement.thousand_fold and amount % 1000 != amount %}
-                            <span class="col"> {{ formatted_amount(amount/1000) }} </span>
-                            <span class="col"> {{ ingredient.measurement.thousand_fold }} </span>
-                        {% else %}
-                            <span class="col"> {{ formatted_amount(amount) }} </span>
-                            <span class="col"> {{ ingredient.measurement.name }} </span>
-                        {% endif %}
-                    </li>
-		    	{% endfor %}
-    		</details>
-    	</li>
+                        <li class="row"> 
+                            <span class="col"> {{ link_or_name(recipe) }} {% if occurences > 1 %}({{ occurences }}x){% endif %} </span>
+                            {% if ingredient.measurement.thousand_fold and amount % 1000 != amount %}
+                                <span class="col"> {{ formatted_amount(amount/1000) }} </span>
+                                <span class="col"> {{ ingredient.measurement.thousand_fold }} </span>
+                            {% else %}
+                                <span class="col"> {{ formatted_amount(amount) }} </span>
+                                <span class="col"> {{ ingredient.measurement.name }} </span>
+                            {% endif %}
+                        </li>
+    		    	{% endfor %}
+        		</details>
+        	</li>
+        {% endfor %}
     {% endfor %}
 </ul>

--- a/app/templates/event_exporter/_ingredient_table.html.j2
+++ b/app/templates/event_exporter/_ingredient_table.html.j2
@@ -1,5 +1,14 @@
-<table class="table">
-    {% for ingredient in ingredients %}
-        {% include "event_exporter/_ingredient_row.html.j2"%}
-    {% endfor %}
-</table>
+{% for group, ingredients in groups.items() %}
+
+    <table class="table">
+        <thead>
+            <th colspan="3">{{ group }}</th>
+        </thead>
+        <tbody>
+        {% for ingredient in ingredients %}
+            {% include "event_exporter/_ingredient_row.html.j2"%}
+        {% endfor %}
+        </tbody>
+    </table>
+
+{% endfor %}

--- a/app/templates/event_exporter/shopping_list.html.j2
+++ b/app/templates/event_exporter/shopping_list.html.j2
@@ -11,7 +11,7 @@
 <h2 class="text-uppercase font-comfortaa">Suroviny (pro {{ event.people_count }} lidí)</h2>
 
 <h3>Trvanlivé</h3>
-{% with ingredients=lasting_ingredients, amounts=lasting_ingredients_shopping.recipe_ingredient_amounts %}
+{% with groups=lasting_ingredients_shopping.grouped_shopping_list, ingredients=lasting_ingredients, amounts=lasting_ingredients_shopping.recipe_ingredient_amounts %}
     {% if show_type == "list" %}
         {% include 'event_exporter/_ingredient_list.html.j2' %}
     {% else %}
@@ -26,7 +26,7 @@
         <h3>Před {{ human_format_date(shopping.date) }}</h3>
     {% endif %}
 
-    {% with ingredients=shopping.shopping_list, amounts=shopping.recipe_ingredient_amounts %}
+    {% with groups=shopping.grouped_shopping_list, ingredients=shopping.shopping_list, amounts=shopping.recipe_ingredient_amounts %}
     {% if show_type == "list" %}
         {% include 'event_exporter/_ingredient_list.html.j2' %}
     {% else %}


### PR DESCRIPTION
Šlo mi o to, aby se suroviny v nákupních seznamech zobrazovaly seskupené podle kategorie, a ta tam byla nadepsaná ➡️ takže při nákupu vidím sekci Ovoce a zelenina a můžu se tam vydat.

Ukázalo se to složitější než jsem myslel, ale vyřešeno.

Celkově ukazuje na dost hrozný stav kódu kolem `_set_shoppings`, bude to někdy chtít zrefaktorovat. 